### PR TITLE
Link to a different repo for 1017

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A simple, curated list of implementations of various [xkcd](https://xkcd.com/) c
   * [Come Closer](https://www.youtube.com/watch?v=eqgy3B7qsdU) - A video implementation of xkcd 941.
   * [Real World Minecraft?](http://www.carbonatedblog.com/2011/08/real-world-minecraft.html) - Another implementation of #941 with Kinects.
 * [#1017 Backward in Time](https://xkcd.com/1017/)
-  * [HistoricProgress](https://github.com/JulianCO/HistoricProgress) - An app that tracks completion of a task implementing the algorithm described in #1017.
+  * [extreme-waiting](https://github.com/extremepayne/extreme-waiting) - Simple script that shows progress, implementing the algorithm described in #1017.
 * [#1110 Click and Drag](https://xkcd.com/1110)
   * [Click and Drag as a Map](http://xkcd-map.rent-a-geek.de) - Click and Drag ported into a Leaflet map interface for viewing pleasure. 
 * [#1133 Up Goer Five](https://xkcd.com/1133)


### PR DESCRIPTION
The previously linked-to repo didn't even have any code, just a readme and a gitignore. The new one kinda sorta works (hey, its better than nothing.)